### PR TITLE
[Enhancement] Add Toggle for Disabling Publish Joint by Topic

### DIFF
--- a/include/aruku/walking/node/walking_node.hpp
+++ b/include/aruku/walking/node/walking_node.hpp
@@ -50,9 +50,7 @@ public:
   using Bool = std_msgs::msg::Bool;
 
   static std::string get_node_prefix();
-  static std::string set_walking_topic();
   static std::string status_topic();
-  static std::string set_odometry_topic();
 
   explicit WalkingNode(
     rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager);

--- a/include/aruku/walking/node/walking_node.hpp
+++ b/include/aruku/walking/node/walking_node.hpp
@@ -48,10 +48,7 @@ public:
   using WalkingStatus = aruku_interfaces::msg::Status;
   using Unit = kansei_interfaces::msg::Unit;
   using Bool = std_msgs::msg::Bool;
-
-  static std::string get_node_prefix();
-  static std::string status_topic();
-
+  
   explicit WalkingNode(
     rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager);
 

--- a/include/aruku/walking/node/walking_node.hpp
+++ b/include/aruku/walking/node/walking_node.hpp
@@ -82,7 +82,7 @@ private:
   int status;
 
   bool action_manager_is_open = false;
-  bool disable_publish_join = false;
+  bool disable_publish_joint = false;
 
 };
 

--- a/include/aruku/walking/node/walking_node.hpp
+++ b/include/aruku/walking/node/walking_node.hpp
@@ -48,7 +48,7 @@ public:
   using WalkingStatus = aruku_interfaces::msg::Status;
   using Unit = kansei_interfaces::msg::Unit;
   using Bool = std_msgs::msg::Bool;
-  
+
   explicit WalkingNode(
     rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager);
 
@@ -77,7 +77,7 @@ private:
   int status;
 
   bool action_manager_is_open = false;
-  bool disable_publish_joint = false;
+  bool disable_publish_joint;
 
 };
 

--- a/include/aruku/walking/node/walking_node.hpp
+++ b/include/aruku/walking/node/walking_node.hpp
@@ -33,6 +33,7 @@
 #include "kansei_interfaces/msg/status.hpp"
 #include "kansei_interfaces/msg/unit.hpp"
 #include "tachimawari_interfaces/msg/set_joints.hpp"
+#include "std_msgs/msg/bool.hpp"
 
 namespace aruku
 {
@@ -46,6 +47,7 @@ public:
   using MeasurementStatus = kansei_interfaces::msg::Status;
   using WalkingStatus = aruku_interfaces::msg::Status;
   using Unit = kansei_interfaces::msg::Unit;
+  using Bool = std_msgs::msg::Bool;
 
   static std::string get_node_prefix();
   static std::string set_walking_topic();
@@ -76,9 +78,12 @@ private:
   rclcpp::Subscription<MeasurementStatus>::SharedPtr measurement_status_subscriber;
   rclcpp::Subscription<Unit>::SharedPtr unit_subscriber;
 
+  rclcpp::Subscription<Bool>::SharedPtr disable_publish_joint_subscriber;
   int status;
 
   bool action_manager_is_open = false;
+  bool disable_publish_join = false;
+
 };
 
 }  // namespace aruku

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -57,7 +57,7 @@ std::string WalkingNode::set_odometry_topic()
 
 WalkingNode::WalkingNode(
   rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager)
-: walking_manager(walking_manager), disable_publish_join(false)
+: walking_manager(walking_manager), disable_publish_joint(false)
 {
   set_walking_subscriber = node->create_subscription<SetWalking>(
     set_walking_topic(), 10,
@@ -73,7 +73,7 @@ WalkingNode::WalkingNode(
 
   disable_publish_joint_subscriber = node->create_subscription<Bool>(
     "/walking/disable_walking", 10, [this](const Bool::SharedPtr message) {
-      this->disable_publish_join = message.get()->data;
+      this->disable_publish_joint = message.get()->data;
     });
 
   measurement_status_subscriber = node->create_subscription<MeasurementStatus>(
@@ -129,7 +129,7 @@ void WalkingNode::publish_joints()
 
   joints_msg.control_type = tachimawari::joint::Middleware::FOR_WALKING;
 
-  if (!disable_publish_join) set_joints_publisher->publish(joints_msg);
+  if (!disable_publish_joint) set_joints_publisher->publish(joints_msg);
 }
 
 void WalkingNode::publish_status()

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -73,7 +73,6 @@ WalkingNode::WalkingNode(
 
   disable_publish_joint_subscriber = node->create_subscription<Bool>(
     "/walking/disable_walking", 10, [this](const Bool::SharedPtr message) {
-      printf("walking disable : %d\n", message.get()->data);
       this->disable_publish_join = message.get()->data;
     });
 

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -24,6 +24,7 @@
 #include "aruku/walking/node/walking_node.hpp"
 
 #include "aruku/walking/node/walking_manager.hpp"
+#include "aruku/walking/node/walking_node.hpp"
 #include "aruku/walking/process/kinematic.hpp"
 #include "kansei/measurement/measurement.hpp"
 #include "keisan/keisan.hpp"
@@ -56,7 +57,7 @@ std::string WalkingNode::set_odometry_topic()
 
 WalkingNode::WalkingNode(
   rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager)
-: walking_manager(walking_manager)
+: walking_manager(walking_manager), disable_publish_join(false)
 {
   set_walking_subscriber = node->create_subscription<SetWalking>(
     set_walking_topic(), 10,
@@ -70,6 +71,11 @@ WalkingNode::WalkingNode(
       }
     });
 
+  disable_publish_joint_subscriber = node->create_subscription<Bool>(
+    "/walking/disable_walking", 10, [this](const Bool::SharedPtr message) {
+      printf("walking disable : %d\n", message.get()->data);
+      this->disable_publish_join = message.get()->data;
+    });
 
   measurement_status_subscriber = node->create_subscription<MeasurementStatus>(
     kansei::measurement::MeasurementNode::status_topic(), 10,
@@ -124,7 +130,7 @@ void WalkingNode::publish_joints()
 
   joints_msg.control_type = tachimawari::joint::Middleware::FOR_WALKING;
 
-  set_joints_publisher->publish(joints_msg);
+  if (!disable_publish_join) set_joints_publisher->publish(joints_msg);
 }
 
 void WalkingNode::publish_status()

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -44,7 +44,7 @@ WalkingNode::WalkingNode(
 : walking_manager(walking_manager), disable_publish_joint(false)
 {
   set_walking_subscriber = node->create_subscription<SetWalking>(
-    "./walking/set_walking", 10, [this](const SetWalking::SharedPtr message) {
+    "/walking/set_walking", 10, [this](const SetWalking::SharedPtr message) {
       if (message->run) {
         this->walking_manager->run(
           message->x_move, message->y_move, message->a_move, message->aim_on);

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -37,18 +37,14 @@ namespace aruku
 
 std::string WalkingNode::get_node_prefix() { return "walking"; }
 
-std::string WalkingNode::set_walking_topic() { return get_node_prefix() + "/set_walking"; }
-
 std::string WalkingNode::status_topic() { return get_node_prefix() + "/status"; }
-
-std::string WalkingNode::set_odometry_topic() { return get_node_prefix() + "/set_odometry"; }
 
 WalkingNode::WalkingNode(
   rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager)
 : walking_manager(walking_manager), disable_publish_joint(false)
 {
   set_walking_subscriber = node->create_subscription<SetWalking>(
-    set_walking_topic(), 10, [this](const SetWalking::SharedPtr message) {
+    "./walking/set_walking", 10, [this](const SetWalking::SharedPtr message) {
       if (message->run) {
         this->walking_manager->run(
           message->x_move, message->y_move, message->a_move, message->aim_on);
@@ -76,7 +72,7 @@ WalkingNode::WalkingNode(
     });
 
   set_odometry_subscriber = node->create_subscription<Point2>(
-    set_odometry_topic(), 10, [this](const Point2::SharedPtr message) {
+    "/walking/set_odometry", 10, [this](const Point2::SharedPtr message) {
       this->walking_manager->set_position(keisan::Point2(message->x, message->y));
     });
 

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -35,16 +35,12 @@
 namespace aruku
 {
 
-std::string WalkingNode::get_node_prefix() { return "walking"; }
-
-std::string WalkingNode::status_topic() { return get_node_prefix() + "/status"; }
-
 WalkingNode::WalkingNode(
   rclcpp::Node::SharedPtr node, std::shared_ptr<WalkingManager> walking_manager)
 : walking_manager(walking_manager), disable_publish_joint(false)
 {
   set_walking_subscriber = node->create_subscription<SetWalking>(
-    "/walking/set_walking", 10, [this](const SetWalking::SharedPtr message) {
+    "walking/set_walking", 10, [this](const SetWalking::SharedPtr message) {
       if (message->run) {
         this->walking_manager->run(
           message->x_move, message->y_move, message->a_move, message->aim_on);
@@ -54,7 +50,7 @@ WalkingNode::WalkingNode(
     });
 
   disable_publish_joint_subscriber = node->create_subscription<Bool>(
-    "/walking/disable_walking", 10,
+    "walking/disable_walking", 10,
     [this](const Bool::SharedPtr message) { this->disable_publish_joint = message.get()->data; });
 
   measurement_status_subscriber = node->create_subscription<MeasurementStatus>(
@@ -63,7 +59,7 @@ WalkingNode::WalkingNode(
       this->walking_manager->update_orientation(keisan::make_degree(message->orientation.yaw));
     });
 
-  status_publisher = node->create_publisher<WalkingStatus>(status_topic(), 10);
+  status_publisher = node->create_publisher<WalkingStatus>("walking/status", 10);
 
   unit_subscriber =
     node->create_subscription<Unit>("/imu/unit", 10, [this](const Unit::SharedPtr message) {
@@ -72,7 +68,7 @@ WalkingNode::WalkingNode(
     });
 
   set_odometry_subscriber = node->create_subscription<Point2>(
-    "/walking/set_odometry", 10, [this](const Point2::SharedPtr message) {
+    "walking/set_odometry", 10, [this](const Point2::SharedPtr message) {
       this->walking_manager->set_position(keisan::Point2(message->x, message->y));
     });
 


### PR DESCRIPTION
## Jira Link: 

## Description
Add a toggle to disable publishing joint states to Tachimawari via the topic `/walking/disable_walking` with `std_msgs::msg::Bool` type to prevent Aruku from always publishing "walk ready" when no motion is being played

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.