### PR TITLE
[Hotfix] - Remove Inverse A Move

### DIFF
--- a/include/aruku/walking/node/walking_manager.hpp
+++ b/include/aruku/walking/node/walking_manager.hpp
@@ -48,7 +48,7 @@ public:
   void set_position(const keisan::Point2 & position);
   const keisan::Point2 & get_position() const;
 
-  void run(double x_move, double y_move, double a_move, bool aim_on = false, bool inverse_a_move = false);
+  void run(double x_move, double y_move, double a_move, bool aim_on = false);
   void stop();
   bool process();
 

--- a/include/aruku/walking/process/kinematic.hpp
+++ b/include/aruku/walking/process/kinematic.hpp
@@ -54,8 +54,7 @@ public:
   bool run_kinematic();
 
   void set_move_amplitude(
-    double x, double y, const keisan::Angle<double> & a, bool aim_on = false, bool inverse_a_move = false);
-  bool is_inverse_a_move() const;
+    double x, double y, const keisan::Angle<double> & a, bool aim_on = false);
 
   double get_x_move_amplitude() const;
   double get_y_move_amplitude() const;
@@ -80,7 +79,6 @@ private:
   double y_move;
   keisan::Angle<double> a_move;
   bool a_move_aim_on;
-  bool inverse_a_move;
 
   // config member
   double period_time;

--- a/src/aruku/walking/node/walking_manager.cpp
+++ b/src/aruku/walking/node/walking_manager.cpp
@@ -192,9 +192,9 @@ const keisan::Point2 & WalkingManager::get_position() const
   return position;
 }
 
-void WalkingManager::run(double x_move, double y_move, double a_move, bool aim_on, bool inverse_a_move)
+void WalkingManager::run(double x_move, double y_move, double a_move, bool aim_on)
 {
-  kinematic.set_move_amplitude(x_move, y_move, keisan::make_degree(a_move), aim_on, inverse_a_move);
+  kinematic.set_move_amplitude(x_move, y_move, keisan::make_degree(a_move), aim_on);
   kinematic.set_running_state(true);
 }
 
@@ -237,12 +237,6 @@ bool WalkingManager::process()
       auto angles = kinematic.get_angles();
       for (auto & joint : joints) {
         uint8_t joint_id = joint.get_id();
-
-        if (kinematic.is_inverse_a_move()) {
-          if (joint_id == JointId::LEFT_HIP_YAW || joint_id == JointId::RIGHT_HIP_YAW) {
-            angles[joint_id] = -angles[joint_id];
-          }
-        }
 
         double offset = joints_direction[joint_id] * Joint::angle_to_value(angles[joint_id]);
 

--- a/src/aruku/walking/node/walking_node.cpp
+++ b/src/aruku/walking/node/walking_node.cpp
@@ -64,7 +64,7 @@ WalkingNode::WalkingNode(
       if (message->run) {
         this->walking_manager->run(
           message->x_move, message->y_move, message->a_move,
-          message->aim_on, message->inverse_a_move);
+          message->aim_on);
       } else {
         this->walking_manager->stop();
       }

--- a/src/aruku/walking/process/kinematic.cpp
+++ b/src/aruku/walking/process/kinematic.cpp
@@ -87,18 +87,12 @@ bool Kinematic::get_running_state() const
 }
 
 void Kinematic::set_move_amplitude(
-  double x, double y, const keisan::Angle<double> & a, bool aim_on, bool inverse_a)
+  double x, double y, const keisan::Angle<double> & a, bool aim_on)
 {
   x_move = x;
   y_move = y;
   a_move = a;
   a_move_aim_on = aim_on;
-  inverse_a_move = inverse_a;
-}
-
-bool Kinematic::is_inverse_a_move() const
-{
-  return inverse_a_move;
 }
 
 double Kinematic::get_x_move_amplitude() const


### PR DESCRIPTION
## Jira Link: 

## Description

```inverse_a_move``` serves the same functionality as ```aim_on```, therefore it is redundant.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.