### PR TITLE
[Feature / PD-420] Adapt Aruku Main to Remove Ros Arguments

### DIFF
--- a/src/aruku_main.cpp
+++ b/src/aruku_main.cpp
@@ -27,14 +27,14 @@
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
+  auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  if (argc < 2) {
+  if (args.size() < 2) {
     std::cerr << "Please specify the path!" << std::endl;
     return 0;
   }
 
-  std::string path = argv[1];
+  std::string path = args[1];
   auto node = std::make_shared<rclcpp::Node>("aruku_node");
   auto aruku_node = std::make_shared<aruku::ArukuNode>(node);
 


### PR DESCRIPTION
## Jira Link: 
https://ichiro-its.atlassian.net/browse/PD-420
## Description

Adjust the main program of aruku to remove ros arguments because ros2 launch automatically appends --ros-args argument after all cmd arguments.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.